### PR TITLE
グラフエリアのスタイル調整

### DIFF
--- a/src/components/GraphArea/GraphArea.jsx
+++ b/src/components/GraphArea/GraphArea.jsx
@@ -13,47 +13,62 @@ import classes from "@/src/components/GraphArea/GraphArea.module.css";
 
 export const GraphArea = ({ series }) => {
   return (
-    <div className={classes.container}>
-      <ResponsiveContainer width="100%" height="100%">
-        <LineChart
-          margin={{
-            top: 20,
-            right: 20,
-            left: 5,
-            bottom: 20,
-          }}
-        >
-          <CartesianGrid />
-          <XAxis
-            dataKey="year"
-            allowDuplicatedCategory={false}
-            label={{
-              value: "年度",
-              position: "insideBottom",
-              offset: -10,
+    <div>
+      <div className={classes.graph}>
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart
+            margin={{
+              top: 20,
+              right: 20,
+              left: 5,
+              bottom: 20,
             }}
-          />
-          <YAxis
-            label={{
-              value: "人口数(万人)",
-              angle: -90,
-              position: "insideLeft",
-            }}
-            tickFormatter={(number) => number / 10000}
-          />
-          <Tooltip />
-          <Legend verticalAlign="top" />
-          {series.map((item, index) => (
-            <Line
-              dataKey="value"
-              data={item.data}
-              name={item.name}
-              key={item.name}
-              stroke={COLORS[index % 9]}
+          >
+            <CartesianGrid />
+            <XAxis
+              dataKey="year"
+              allowDuplicatedCategory={false}
+              label={{
+                value: "年度",
+                position: "insideBottom",
+                offset: -10,
+              }}
             />
-          ))}
-        </LineChart>
-      </ResponsiveContainer>
+            <YAxis
+              label={{
+                value: "人口数(万人)",
+                angle: -90,
+                position: "insideLeft",
+              }}
+              tickFormatter={(number) => number / 10000}
+            />
+            <Tooltip />
+            {series.map((item, index) => (
+              <Line
+                dataKey="value"
+                data={item.data}
+                name={item.name}
+                key={item.name}
+                stroke={COLORS[index % 9]}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+      <div className={classes.legend}>
+        <ResponsiveContainer height="100%">
+          <LineChart data={[{}]}>
+            <Legend verticalAlign="top" />
+            {series.map((item, index) => (
+              <Line
+                dataKey={item.name}
+                key={item.name}
+                stroke={COLORS[index % 9]}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
     </div>
   );
 };

--- a/src/components/GraphArea/GraphArea.jsx
+++ b/src/components/GraphArea/GraphArea.jsx
@@ -14,11 +14,12 @@ import classes from "@/src/components/GraphArea/GraphArea.module.css";
 export const GraphArea = ({ series }) => {
   return (
     <div>
+      <h2 className={classes.title}>人口構成</h2>
       <div className={classes.graph}>
         <ResponsiveContainer width="100%" height="100%">
           <LineChart
             margin={{
-              top: 20,
+              top: 5,
               right: 20,
               left: 5,
               bottom: 20,

--- a/src/components/GraphArea/GraphArea.jsx
+++ b/src/components/GraphArea/GraphArea.jsx
@@ -9,15 +9,17 @@ import {
   YAxis,
 } from "recharts";
 
+import classes from "@/src/components/GraphArea/GraphArea.module.css";
+
 export const GraphArea = ({ series }) => {
   return (
-    <div style={{ height: "400px", marginTop: "20px" }}>
+    <div className={classes.container}>
       <ResponsiveContainer width="100%" height="100%">
         <LineChart
           margin={{
             top: 20,
-            right: 50,
-            left: 30,
+            right: 20,
+            left: 5,
             bottom: 20,
           }}
         >
@@ -33,11 +35,11 @@ export const GraphArea = ({ series }) => {
           />
           <YAxis
             label={{
-              value: "人口数",
+              value: "人口数(万人)",
               angle: -90,
               position: "insideLeft",
-              offset: -10,
             }}
+            tickFormatter={(number) => number / 10000}
           />
           <Tooltip />
           <Legend verticalAlign="top" />

--- a/src/components/GraphArea/GraphArea.module.css
+++ b/src/components/GraphArea/GraphArea.module.css
@@ -1,0 +1,4 @@
+.container {
+  height: 50vh;
+  margintop: 20px;
+}

--- a/src/components/GraphArea/GraphArea.module.css
+++ b/src/components/GraphArea/GraphArea.module.css
@@ -1,4 +1,9 @@
-.container {
+.graph {
   height: 50vh;
-  margintop: 20px;
+  margin-top: 20px;
+}
+
+.legend {
+  height: 75vh; /* 凡例領域の確保 */
+  margin-top: 5px;
 }

--- a/src/components/GraphArea/GraphArea.module.css
+++ b/src/components/GraphArea/GraphArea.module.css
@@ -1,9 +1,12 @@
 .graph {
   height: 50vh;
-  margin-top: 20px;
 }
 
 .legend {
   height: 75vh; /* 凡例領域の確保 */
   margin-top: 5px;
+}
+
+.title {
+  border-bottom: solid 3px #f4a47f;
 }

--- a/src/components/PopulationGraphByPrefecture/PopulationGraphByPrefecture.jsx
+++ b/src/components/PopulationGraphByPrefecture/PopulationGraphByPrefecture.jsx
@@ -27,9 +27,7 @@ export const PopulationGraphByPrefecture = () => {
 
   return (
     <div className={styles.container}>
-      <div>
-        <SelectPrefectureArea onChange={handleChange} />
-      </div>
+      <SelectPrefectureArea onChange={handleChange} />
       <GraphArea series={series} />
     </div>
   );

--- a/src/components/PopulationGraphByPrefecture/PopulationGraphByPrefecture.jsx
+++ b/src/components/PopulationGraphByPrefecture/PopulationGraphByPrefecture.jsx
@@ -27,10 +27,10 @@ export const PopulationGraphByPrefecture = () => {
 
   return (
     <div className={styles.container}>
-      <GraphArea series={series} />
       <div>
         <SelectPrefectureArea onChange={handleChange} />
       </div>
+      <GraphArea series={series} />
     </div>
   );
 };

--- a/src/components/SelectPrefectureArea/SelectPrefectureArea.module.css
+++ b/src/components/SelectPrefectureArea/SelectPrefectureArea.module.css
@@ -1,7 +1,6 @@
 .prefectureArea {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-around;
 }
 
 .title {

--- a/src/pages/api/hello.js
+++ b/src/pages/api/hello.js
@@ -1,5 +1,0 @@
-// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-
-export default function handler(req, res) {
-  res.status(200).json({ name: 'John Doe' })
-}


### PR DESCRIPTION
- グラフエリアのスタイルを調整しました。
- 凡例を切り出して、都道府県を追加するとグラフが小さくなる問題を解決しました。

![image](https://user-images.githubusercontent.com/63224540/161435029-e6053017-68b9-4057-a5a0-274a738da297.png)
![image](https://user-images.githubusercontent.com/63224540/161435040-b83635da-890c-4b4b-821e-a78a47fff4f7.png)
